### PR TITLE
Load secrets from env or st.secrets

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This application is a Streamlit-based tool that utilizes NLP and Neo4j to genera
 * **Relationship-Aware Filtering**: Ensures key columns related to relationships are retained.
 * **SQL Query Generation**: Uses ArliAI API to generate SQL queries based on the refined schema.
 * **Configurable Similarity Threshold**: Allows fine-tuning relevance detection for query context.
-* **Secure Credentials Input**: Uses password fields for sensitive information in Streamlit UI.
+* **Environment-Based Secrets**: Credentials are loaded from `.env` or `st.secrets` with a UI fallback for local development.
 
 ## Setup
 
@@ -39,7 +39,18 @@ This application is a Streamlit-based tool that utilizes NLP and Neo4j to genera
    pip install -r requirements.txt
    ```
 
-4. **Run the app**
+4. **Create a `.env` file**
+   Define the following variables (or use `st.secrets` in a deployed environment):
+
+   ```dotenv
+   NEO4J_URI=bolt://localhost:7687
+   NEO4J_USER=neo4j
+   NEO4J_PASSWORD=your_password
+   NEO4J_DATABASE=e-commerce
+   ARLIAI_API_KEY=your_api_key
+   ```
+
+5. **Run the app**
 
    ```sh
    streamlit run app.py
@@ -55,12 +66,16 @@ streamlit run app.py
 
 ### Configuring Inputs
 
-* **Neo4j URI**: The connection string for Neo4j (e.g., `bolt://localhost:7687`).
-* **Neo4j User & Password**: Authentication credentials.
-* **Database Name**: The Neo4j database containing the schema.
-* **ArliAI API Key**: Required to generate SQL queries.
-* **Similarity Threshold**: Adjusts the sensitivity for schema relevance detection.
-* **User Query**: Natural language input describing the desired SQL query.
+Set the required variables in a `.env` file or `st.secrets` as shown above. If a
+variable is missing, the app will display a text input in the sidebar so you can
+provide it manually during local development.
+
+* **Neo4j URI** – connection string for Neo4j (e.g., `bolt://localhost:7687`).
+* **Neo4j User & Password** – authentication credentials.
+* **Database Name** – the Neo4j database containing the schema.
+* **ArliAI API Key** – required to generate SQL queries.
+* **Similarity Threshold** – adjusts the sensitivity for schema relevance detection.
+* **User Query** – natural language input describing the desired SQL query.
 
 ### Workflow
 

--- a/app.py
+++ b/app.py
@@ -13,6 +13,27 @@ from sklearn.metrics.pairwise import cosine_similarity
 import json
 import requests
 import re
+import os
+from dotenv import load_dotenv
+
+# Load environment variables from a .env file if present
+load_dotenv()
+
+# Helper to fetch configuration from environment or Streamlit secrets
+def get_config(label: str, env_key: str, default: str = "", password: bool = False):
+    """Retrieve a configuration value.
+
+    Preference is given to ``st.secrets`` followed by environment variables.
+    If neither is set, a sidebar text input is shown as a fallback for local
+    development.
+    """
+    value = st.secrets.get(env_key) if env_key in st.secrets else os.getenv(env_key)
+    if value:
+        st.sidebar.text_input(label, value="Loaded from environment", disabled=True)
+        return value
+    if password:
+        return st.sidebar.text_input(label, value=default, type="password")
+    return st.sidebar.text_input(label, value=default)
 
 # Neo4j Handler
 class Neo4jHandler:
@@ -461,11 +482,11 @@ def main():
 
     # Inputs
     st.sidebar.header("Configuration")
-    neo4j_uri = st.sidebar.text_input("Neo4j URI", "bolt://localhost:7687")
-    neo4j_user = st.sidebar.text_input("Neo4j User", "neo4j")
-    neo4j_password = st.sidebar.text_input("Neo4j Password", type="password")
-    database_name = st.sidebar.text_input("Database Name", "e-commerce")
-    arliAI_api_key = st.sidebar.text_input("ArliAI API Key", type="password")
+    neo4j_uri = get_config("Neo4j URI", "NEO4J_URI", "bolt://localhost:7687")
+    neo4j_user = get_config("Neo4j User", "NEO4J_USER", "neo4j")
+    neo4j_password = get_config("Neo4j Password", "NEO4J_PASSWORD", password=True)
+    database_name = get_config("Database Name", "NEO4J_DATABASE", "e-commerce")
+    arliAI_api_key = get_config("ArliAI API Key", "ARLIAI_API_KEY", password=True)
 
     # Sliders for Top-K control
     top_k_tables = st.sidebar.slider(

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ sentence-transformers
 scikit-learn
 requests
 sqlglot>=23.0.0
+python-dotenv


### PR DESCRIPTION
## Summary
- pull Neo4j and API credentials from `.env` or `st.secrets`
- show disabled sidebar fields when secrets are loaded
- document .env configuration and update features list
- add python-dotenv dependency

## Testing
- `pip install python-dotenv`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684d6701bbc083339532f7b7ab857bab